### PR TITLE
feat(2-5): fix doodle provider pre-filter + fuzzy breed recommendation text

### DIFF
--- a/frontend/app/api/dogs/route.ts
+++ b/frontend/app/api/dogs/route.ts
@@ -5,6 +5,32 @@ import { Dog as SchemaDog } from '@/lib/schemas';
 import { getActiveDogProvider, type SearchDogsParams } from '@/lib/dogProviders';
 import type { Dog as ProviderDog } from '@/lib/api';
 
+// Canonical map for provider pre-filter (RescueGroups-friendly names only).
+// This is a performance hint — the AI matching layer handles hard filtering.
+const PROVIDER_BREED_CANONICAL: Record<string, string> = {
+  'doodle': 'poodle',
+  'goldendoodle': 'poodle',
+  'labradoodle': 'poodle',
+  'bernedoodle': 'poodle',
+  'sheepadoodle': 'poodle',
+  'aussiedoodle': 'poodle',
+  'poodle mix': 'poodle',
+  'lab': 'labrador retriever',
+  'lab mix': 'labrador retriever',
+  'labrador': 'labrador retriever',
+  'labrador mix': 'labrador retriever',
+  'golden': 'golden retriever',
+  'gsd': 'german shepherd',
+  'pit': 'pit bull',
+  'pitbull': 'pit bull',
+};
+
+function canonicalizeForProvider(breeds: string[]): string[] {
+  return [...new Set(
+    breeds.map(b => PROVIDER_BREED_CANONICAL[b.toLowerCase().trim()] ?? b)
+  )];
+}
+
 export async function GET(request: NextRequest) {
   const startTime = Date.now();
   const requestId = `req-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
@@ -29,12 +55,14 @@ export async function GET(request: NextRequest) {
     // Normalize query for provider
     const limit = Math.min(parseInt(searchParams.get('limit') || '20', 10) || 20, 20);
     const page = parseInt(searchParams.get('page') || '1', 10) || 1;
+    const rawIncludeBreeds = searchParams.get('includeBreeds')?.split(',').filter(Boolean) || [];
+    const canonicalIncludeBreeds = canonicalizeForProvider(rawIncludeBreeds);
     const providerParams: SearchDogsParams = {
       zip: searchParams.get('zip') || undefined,
       radius: searchParams.get('radius') ? parseInt(searchParams.get('radius') as string, 10) : undefined,
       age: searchParams.get('age') || undefined,
       size: searchParams.get('size') || undefined,
-      includeBreeds: searchParams.get('breed') || undefined,
+      includeBreeds: canonicalIncludeBreeds.length > 0 ? canonicalIncludeBreeds.join(',') : undefined,
       sort: (searchParams.get('sort') as any) || 'freshness',
       page,
       limit,

--- a/frontend/lib/explanation.ts
+++ b/frontend/lib/explanation.ts
@@ -142,7 +142,10 @@ function createTop3Prompt(dog: Dog, analysis: DogAnalysis, effectivePrefs: Effec
     `Pronouns: ${pronouns.subject}/${pronouns.object}/${pronouns.possessiveAdjective} (${pronouns.noun})`,
     hasDescription ? `Shelter description: ${sanitizedDescription}` : '',
     `Matched facets: ${JSON.stringify(matched_facets)}`,
-    breed_exact ? `Exact breed label: ${breed_label}` : ''
+    breed_exact ? `Exact breed label: ${breed_label}` : '',
+    (!breed_exact && breed_fuzzy && effectivePrefs.breeds.include.length > 0)
+      ? `Breed preference (fuzzy match): ${effectivePrefs.breeds.include.join(', ')}`
+      : ''
   ].filter(Boolean).join('\n');
 
   return `${header}\n\n${body}`;


### PR DESCRIPTION
## Summary

- **Bug A fix:** Added `PROVIDER_BREED_CANONICAL` map + `canonicalizeForProvider()` in `dogs/route.ts` to translate colloquial breed terms (doodle → poodle, lab mix → labrador retriever, etc.) to RescueGroups-compatible names before querying the provider. Also fixes the param name bug from story 2-3 (`breed` → `includeBreeds`).
- **Bug B fix:** Added fuzzy breed context line to `createTop3Prompt` body in `explanation.ts` — when `breed_fuzzy=true` and `breed_exact=false`, the LLM now receives `"Breed preference (fuzzy match): doodle"` so it can write meaningful breed-referencing recommendation text.

## Test plan

- [ ] Enter "doodle" as include breed on /find → verify poodle-mix dogs appear in Top Picks and All Matches
- [ ] Verify Top Picks recommendation text mentions the breed connection (e.g., "doodle preference", "poodle mix")
- [ ] Re-test "lab mix" → still returns Lab/Lab-mix dogs (regression check)
- [ ] Re-test "golden", "gsd" → still resolve correctly (regression check)
- [ ] Re-test size, age, temperament, guidance filters → no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)